### PR TITLE
Add Google Maps for Work signing support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -78,6 +78,7 @@ Next, add the following to your application.rb file, or before you perform a coo
 
     Timezone::Configure.begin do |c|
       c.google_api_key = 'your_google_api_key_goes_here'
+      c.google_client_id = 'your_google_client_id' # only if using 'Google for Work'
     end
 
 Finally, for either geonames or Google implementation, pass the coordinates to your timezone initialization function.

--- a/lib/timezone/configure.rb
+++ b/lib/timezone/configure.rb
@@ -40,11 +40,34 @@ module Timezone
       @google_api_key = api_key
     end
 
+    # The Google Client ID (for enterprise)
+    #
+    # @return [String]
+    #   the Google Client ('abc123')
+    def self.google_client_id
+      @google_client_id ||= nil
+    end
+
+    # Google Client ID (for enterprise)
+    #
+    # @param [String] client
+    #   the Google Client
+    def self.google_client_id=(client)
+      @google_client_id = client
+    end
+
     # Use Google API if key has been set
     #
     # @return [Boolean]
     def self.use_google?
       !!google_api_key
+    end
+
+    # Sign Google API request if client given (for enterprise)
+    #
+    # @return [Boolean]
+    def self.use_google_enterprise?
+      use_google? && !!google_client_id
     end
 
     def self.lookup

--- a/lib/timezone/lookup/google.rb
+++ b/lib/timezone/lookup/google.rb
@@ -2,6 +2,9 @@ require 'timezone/lookup/basic'
 require 'timezone/error'
 require 'json'
 require 'uri'
+require 'base64'
+require 'openssl'
+require 'cgi'
 
 module Timezone
   module Lookup
@@ -15,6 +18,10 @@ module Timezone
 
       def lookup(lat,lng)
         response = client.get(url(lat,lng))
+
+        if response.code == '403'
+          raise(Timezone::Error::Google, '403 Forbidden')
+        end
 
         return unless response.code =~ /^2\d\d$/
         data = JSON.parse(response.body)
@@ -30,13 +37,27 @@ module Timezone
 
       private
 
-      def url(lat,lng)
-          query = URI.encode_www_form(
-            'location' => "#{lat},#{lng}",
-            'timestamp' => Time.now.to_i,
-            'key' => config.google_api_key)
+      def authorize(url)
+        if config.use_google_enterprise?
+          url += "&client=#{CGI.escape(config.google_client_id)}"
 
-          "/maps/api/timezone/json?#{query}"
+          sha1 = OpenSSL::Digest.new('sha1')
+          binary_key = Base64.decode64(config.google_api_key.tr('-_','+/'))
+          binary_signature = OpenSSL::HMAC.digest(sha1, binary_key, url)
+          signature = Base64.encode64(binary_signature).tr('+/','-_').strip
+
+          url + "&signature=#{signature}"
+        else
+          url + "&key=#{config.google_api_key}"
+        end
+      end
+
+      def url(lat,lng)
+        query = URI.encode_www_form(
+          'location' => "#{lat},#{lng}",
+          'timestamp' => Time.now.to_i)
+
+        authorize("/maps/api/timezone/json?#{query}")
       end
     end
   end

--- a/test/google_lookup_test.rb
+++ b/test/google_lookup_test.rb
@@ -1,13 +1,14 @@
 require 'timezone/configure'
 require 'timezone/lookup/google'
 require 'minitest/autorun'
+require 'timecop'
 require_relative 'http_test_client'
 
 class GoogleLookupTest < ::Minitest::Unit::TestCase
   def setup
     Timezone::Configure.begin do |c|
       c.http_client = HTTPTestClient
-      c.google_api_key = '123abc'
+      c.google_api_key = 'MTIzYWJj'
     end
   end
 
@@ -23,7 +24,7 @@ class GoogleLookupTest < ::Minitest::Unit::TestCase
     Timezone::Configure.begin{ |c| c.google_api_key = nil }
     assert_raises(::Timezone::Error::InvalidConfig){ lookup }
   ensure
-    Timezone::Configure.begin{ |c| c.google_api_key = '123abc' }
+    Timezone::Configure.begin{ |c| c.google_api_key = 'MTIzYWJj' }
   end
 
   def test_google_using_lat_lon_coordinates
@@ -36,6 +37,29 @@ class GoogleLookupTest < ::Minitest::Unit::TestCase
     HTTPTestClient.body = nil
     assert_raises Timezone::Error::Google, 'The provided API key is invalid.' do
       lookup.lookup(*coordinates)
+    end
+  end
+
+  def test_url_non_enterprise
+    Timecop.freeze(Time.at(1433347661)) do
+      result = lookup.send(:url, '123', '123')
+      assert_equal "/maps/api/timezone/json?location=123%2C123&timestamp=1433347661&key=MTIzYWJj", result
+    end
+  end
+
+  def test_url_enterprise
+    Timezone::Configure.begin do |c|
+      c.google_client_id = '123&asdf'
+    end
+
+    Timecop.freeze(Time.at(1433347661)) do
+      result = lookup.send(:url, '123', '123')
+      assert_equal '/maps/api/timezone/json?location=123%2C123&timestamp=1433347661&client=123%26asdf&signature=B1TNSSvIw9Wvf_ZjjW5uRzGm4F4=', result
+    end
+
+  ensure
+    Timezone::Configure.begin do |c|
+      c.google_client_id = nil
     end
   end
 


### PR DESCRIPTION
The Google Maps API for businesses requires signing requests according
to this specification [1]. This change allows signing such requests.

In addition we've added one error handling case that provides more
information when a 403 response is returned as the previous response was
misleading.

1.
https://developers.google.com/maps/documentation/business/webservices/
